### PR TITLE
Remove references to cacheId property in payload

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,12 +77,6 @@ app.post('/', function (req, res) {
     }
   };
 
-  // append the cacheId, if needed.
-  // if it was present in the original event, it is required.
-  if (event.cacheId) {
-    requestOptions.json.cacheId = event.cacheId;
-  }
-
   // dispatch the push notification
   request(requestOptions, function (err, response) {
     if (err) {

--- a/validations.js
+++ b/validations.js
@@ -17,7 +17,6 @@ var pushEventSchema = Joi.object().keys({
       .when('header.type', { is: ['message', 'signal'], then: Joi.required() })
   }),
   pushNotificationId: Joi.string(),
-  cacheId: Joi.string().optional(),
   config: Joi.object()
 });
 


### PR DESCRIPTION
cacheId is being removed from the payload sent to a push event,
so this patch removes reference to it.

Related to MER-3859
